### PR TITLE
US-6: Add functionality and tests to conditionally show application s…

### DIFF
--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -8,6 +8,10 @@ class ApplicationsController < ApplicationController
             pet_id = params[:added_pet]
             @application.add_pet_to_application(pet_id)
         end
+
+        if params[:pet_ownership_description].present?
+            @application.change_application_status("Pending")
+        end
     end
     
     def new 

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -17,4 +17,8 @@ class Application < ApplicationRecord
     pet = Pet.find(pet_id)
     self.pets << pet
   end
+
+  def change_application_status(new_status)
+    self.status = new_status
+  end
 end

--- a/app/views/applications/show.html.erb
+++ b/app/views/applications/show.html.erb
@@ -14,37 +14,46 @@
     <% end %>
 </ul>
 
-<%# <p><%= link_to "Update #{@application.name}", "pets/#{@application.id}/edit" %></p>
-<%# #<p><%= link_to "Delete #{@application.name}", "/pets/#{@application.id}", method: :delete %></p>
-<p>Search for a pet to add</p>
-<%= form_with url: "/applications/#{@application.id}", method: :get, local: true do |f| %>
-  <%= f.label :search %>
-  <%= f.text_field :search %>
-  <%= f.submit "Search" %>
+<% if @application.pets.present? %>
+    <% if @application.status == "In Progress" %>
+        <%= form_with url: "/applications/#{@application.id}", method: :get, local: true do |f| %>
+            <h3><%= f.label :pet_ownership_description, "Why would you be a good owner to the pet(s)?" %></h3>
+            <%= f.text_area :pet_ownership_description %><br><br>
+            <%= f.submit "Submit Application" %>
+        <% end %>
+    <% end %> 
 <% end %>
 
-<h3>Adoptable Pets </h3>
+<%# <p><%= link_to "Update #{@application.name}", "pets/#{@application.id}/edit" %></p>
+<%# #<p><%= link_to "Delete #{@application.name}", "/pets/#{@application.id}", method: :delete %></p>
 
-<% if @pets.nil? %>
-    <p>No Pets Found </p>
-<% else %>
-    
-    <ol>
-        <% @pets.each do |pet| %>
+<% if @application.status == "In Progress" %>
+    <%= form_with url: "/applications/#{@application.id}", method: :get, local: true do |f| %>
+        <h3><%= f.label :search, "Search for a pet to add:" %></h3>
+        <%= f.text_field :search %>
+        <%= f.submit "Search" %>
+    <% end %>
 
-            <li><%= pet.name %></li>
-            <ul>
-                <li><%= pet.age %></li>
-                <li><%= pet.breed %></li>
-                <li><%= pet.adoptable %></li>
-            </ul>
-            </li>
-            <%= form_with url: "/applications/#{@application.id}", method: :get, local: true do |f| %>
-                <%= f.hidden_field :added_pet, value: pet.id %>
-                <%= f.submit "Adopt #{pet.name}" %>
-            <% end %>
-        <%end %> 
-    </ol>
+    <h3>Adoptable Pets:</h3>
+    <% if @pets.nil? %> 
+        <p>No Pets Found </p>
+    <% else %> 
+        <ol>
+            <% @pets.each do |pet| %>
+                <li><%= pet.name %></li>
+                <ul>
+                    <li><%= pet.age %></li>
+                    <li><%= pet.breed %></li>
+                    <li><%= pet.adoptable %></li>
+                </ul>
+                </li>
+                <%= form_with url: "/applications/#{@application.id}", method: :get, local: true do |f| %>
+                    <%= f.hidden_field :added_pet, value: pet.id %>
+                    <%= f.submit "Adopt #{pet.name}" %>
+                <% end %>
+            <%end %> 
+        </ol>
+    <% end %>
 <% end %>
 
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,6 +7,7 @@
 #   Character.create(name: "Luke", movie: movies.first)
 
 shelter = Shelter.create(name: "Mystery Building", city: "Irvine CA", foster_program: false, rank: 9)
-applicant = Application.create(name: "Shaggy", street_address: "123 Mystery Lane", city: "Irvine", state: "CA", zip_code: "91010", description: "Because Scoob and I love Scooby Snacks")
-pet = applicant.pets.create(name: "Scooby", age: 2, breed: "Great Dane", adoptable: true, shelter_id: shelter.id)
+applicant_who_has_pets = Application.create(name: "Shaggy", street_address: "123 Mystery Lane", city: "Irvine", state: "CA", zip_code: "91010", description: "Because")
+applicant_who_has_no_pets = Application.create(name: "Daphne", street_address: "4 North Street", city: "Boulder", state: "CO", zip_code: "80209", description: "I want a pet")
+pet = applicant_who_has_pets.pets.create(name: "Scooby", age: 2, breed: "Great Dane", adoptable: true, shelter_id: shelter.id)
 cat = Pet.create(name: "Catdog", age: 4, breed: "Calico", adoptable: true, shelter_id: shelter.id)

--- a/spec/features/applications/show_spec.rb
+++ b/spec/features/applications/show_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe "the application show page" do
     fill_in "Search", with: "scoob"
 
     click_button "Search"
-    # save_and_open_page
+    save_and_open_page
     expect(page).to have_content("Scooby")
     
   end
@@ -99,6 +99,60 @@ RSpec.describe "the application show page" do
     expect(page).to have_content("Scooby")
     save_and_open_page
   end
+
+  it "shows a section to explain why I'd make a good owner if I have chosen pets to adopt" do
+    shelter = Shelter.create(name: "Mystery Building", city: "Irvine CA", foster_program: false, rank: 9)
+    applicant = Application.create(name: "Shaggy", street_address: "123 Mystery Lane", city: "Irvine", state: "CA", zip_code: "91010", description: "Because ")
+    pet = applicant.pets.create(name: "Scooby", age: 2, breed: "Great Dane", adoptable: true, shelter_id: shelter.id)
+
+    visit "/applications/#{applicant.id}"
+
+    expect(page).to have_content("Why would you be a good owner")
+    expect(page).to have_field("Why would you be a good owner to the pet(s)?")
+  end
+  
+  it "does NOT show a section to explain why I'd make a good owner if I have NOT chosen pets to adopt" do
+    shelter = Shelter.create(name: "Mystery Building", city: "Irvine CA", foster_program: false, rank: 9)
+    applicant = Application.create(name: "Shaggy", street_address: "123 Mystery Lane", city: "Irvine", state: "CA", zip_code: "91010", description: "Because ")
+    pet = Pet.create(name: "Scooby", age: 2, breed: "Great Dane", adoptable: true, shelter_id: shelter.id)
+
+    visit "/applications/#{applicant.id}"
+
+    expect(page).to_not have_content("Why would you be a good owner")
+    expect(page).to_not have_field("Why would you be a good owner")
+  end
+
+  it "shows applicant's changed status from In Progress to Pending after application is submitted" do
+    shelter = Shelter.create(name: "Mystery Building", city: "Irvine CA", foster_program: false, rank: 9)
+    applicant = Application.create(name: "Shaggy", street_address: "123 Mystery Lane", city: "Irvine", state: "CA", zip_code: "91010", description: "Because ")
+    pet = applicant.pets.create(name: "Scooby", age: 2, breed: "Great Dane", adoptable: true, shelter_id: shelter.id)
+
+    visit "/applications/#{applicant.id}"
+
+    expect(page).to have_content("In Progress")
+
+    fill_in "Why would you be a good owner to the pet(s)?", with: "because I loooove them"
+    click_button "Submit Application"
+
+    expect(page).to have_content("Pending")
+
+  end
+
+  it "does NOT show section to add more pets to the application if application status is Pending" do
+    shelter = Shelter.create(name: "Mystery Building", city: "Irvine CA", foster_program: false, rank: 9)
+    applicant = Application.create(name: "Shaggy", street_address: "123 Mystery Lane", city: "Irvine", state: "CA", zip_code: "91010", description: "Because ")
+    pet = applicant.pets.create(name: "Scooby", age: 2, breed: "Great Dane", adoptable: true, shelter_id: shelter.id)
+    cat = Pet.create(name: "Catdog", age: 4, breed: "Calico", adoptable: true, shelter_id: shelter.id)
+
+    visit "/applications/#{applicant.id}"
+
+    fill_in "Why would you be a good owner to the pet(s)?", with: "because I loooove them"
+    click_button "Submit Application"
+
+    expect(page).to_not have_content("Search for a pet to add")
+    expect(page).to_not have_button("Adopt Catdog")
+  end
+
   # it "allows the user to delete a pet" do
   #   shelter = Shelter.create(name: "Mystery Building", city: "Irvine CA", foster_program: false, rank: 9)
   #   pet = Pet.create(name: "Scrappy", age: 1, breed: "Great Dane", adoptable: true, shelter_id: shelter.id)

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -32,5 +32,15 @@ RSpec.describe Application, type: :model do
       end
     end
 
+    describe "#change_application_status" do
+      it "changes status from In Progress to Pending when application is submitted" do
+        expect(@applicant.status).to eq("In Progress")
+
+        @applicant.change_application_status("Pending")
+
+        expect(@applicant.status).to eq("Pending")
+      end
+    end
+
     
 end


### PR DESCRIPTION
US-6: Add functionality and tests to conditionally show application submission fields and pet search functionality according to applicant's current status.

```
6. Submit an Application

As a visitor
When I visit an application's show page
And I have added one or more pets to the application
Then I see a section to submit my application
And in that section I see an input to enter why I would make a good owner for these pet(s)
When I fill in that input
And I click a button to submit this application
Then I am taken back to the application's show page
And I see an indicator that the application is "Pending"
And I see all the pets that I want to adopt
And I do not see a section to add more pets to this application
```