### PR TITLE
Add test for Case Insensitive Matches for Pet Names

### DIFF
--- a/spec/features/applications/show_spec.rb
+++ b/spec/features/applications/show_spec.rb
@@ -187,6 +187,20 @@ RSpec.describe "the application show page" do
     expect(page).to have_content("Scooby")
     
   end
+
+  it " Successfully searches pets with case insensitive inputs" do 
+    shelter = Shelter.create(name: "Mystery Building", city: "Irvine CA", foster_program: false, rank: 9)
+    applicant = Application.create(name: "Shaggy", street_address: "123 Mystery Lane", city: "Irvine", state: "CA", zip_code: "91010", description: "Because ")
+    pet = Pet.create(name: "Scooby", age: 2, breed: "Great Dane", adoptable: true, shelter_id: shelter.id)
+
+    visit "/applications/#{applicant.id}"
+    # save_and_open_page
+    fill_in "Search", with: "SCoOb"
+
+    click_button "Search"
+    # save_and_open_page
+    expect(page).to have_content("Scooby")
+  end
   # it "allows the user to delete a pet" do
   #   shelter = Shelter.create(name: "Mystery Building", city: "Irvine CA", foster_program: false, rank: 9)
   #   pet = Pet.create(name: "Scrappy", age: 1, breed: "Great Dane", adoptable: true, shelter_id: shelter.id)


### PR DESCRIPTION
9. Case Insensitive Matches for Pet Names

As a visitor
When I visit an application show page
And I search for Pets by name
Then my search is case insensitive
For example, if I search for "fluff", my search would match pets with names "Fluffy", "FLUFF", and "Mr. FlUfF"
