### PR TITLE
Us 12 approving a pet for adoption

### DIFF
--- a/app/controllers/admin/applications_controller.rb
+++ b/app/controllers/admin/applications_controller.rb
@@ -1,0 +1,22 @@
+class Admin::ApplicationsController < ApplicationController
+    def show
+        @application = Application.find(params[:id])
+        
+        @pets = Pet.search(params[:search])
+        
+        if params[:added_pet].present? 
+            pet_id = params[:added_pet]
+            @application.add_pet_to_application(pet_id)
+        end
+
+        if params[:pet_ownership_description].present?
+            @application.change_application_status("Pending")
+        end
+
+        if params[:approved_pet_id].present?
+            pet_id = params[:approved_pet_id]
+            application_pet = ApplicationPet.where({pet_id: pet_id},{application_id: @application.id}).first
+            application_pet.change_application_pet_status("Approved")
+        end
+    end
+end

--- a/app/models/application_pet.rb
+++ b/app/models/application_pet.rb
@@ -1,4 +1,8 @@
 class ApplicationPet < ApplicationRecord
     belongs_to :application
     belongs_to :pet
+
+    def change_application_pet_status(new_status)
+        self.update(status: new_status)
+    end
 end

--- a/app/models/pet.rb
+++ b/app/models/pet.rb
@@ -13,4 +13,9 @@ class Pet < ApplicationRecord
   def self.adoptable
     where(adoptable: true)
   end
+
+  def add_pet_to_application(pet_id)
+    pet = Pet.find(pet_id)
+    self.pets << pet
+  end
 end

--- a/app/views/admin/applications/show.html.erb
+++ b/app/views/admin/applications/show.html.erb
@@ -1,0 +1,61 @@
+<h1><%= @application.name %></h1>
+
+<h3>Street Address: <%= @application.street_address %></h3>
+<h3>City: <%= @application.city %></h3>
+<h3>State: <%= @application.state %></h3>
+<h3>Zip Code: <%= @application.zip_code %></h3>
+<h3>Reason for applying: <%= @application.description %></h3>
+<h3>Application Status: <%= @application.status %></h3>
+
+<h3>Applying for pets: </h3>
+<ul>
+    <% @application.pets.each do |pet| %>
+        <li><p><%= link_to "#{pet.name}", "/pets/#{pet.id}" %></p></li>
+        <% if ApplicationPet.where({pet_id: pet.id},{application_id: @application.id}).first.status != "Approved" %>
+            <%= form_with url: "/admin/applications/#{@application.id}", method: :get, local: true do |f| %>
+                <%= f.hidden_field :approved_pet_id, value: pet.id %>
+                <%= f.submit "Approve #{pet.name}" %>
+            <% end %>
+        <% else %>
+            <%= "(#{pet.name} already approved)" %>
+        <% end %>   
+    <% end %>
+</ul>
+
+<%# <p><%= link_to "Update #{@application.name}", "pets/#{@application.id}/edit" %></p>
+<%# #<p><%= link_to "Delete #{@application.name}", "/pets/#{@application.id}", method: :delete %></p>
+
+<% if @application.status == "In Progress" %>
+    <%= form_with url: "/applications/#{@application.id}", method: :get, local: true do |f| %>
+        <h3><%= f.label :search, "Search for a pet to add:" %></h3>
+        <%= f.text_field :search %>
+        <%= f.submit "Search" %>
+    <% end %>
+
+    <h3>Adoptable Pets:</h3>
+    <% if @pets.nil? %> 
+        <p>No Pets Found </p>
+    <% else %> 
+        <ol>
+            <% @pets.each do |pet| %>
+                <li><%= pet.name %></li>
+                <ul>
+                    <li><%= pet.age %></li>
+                    <li><%= pet.breed %></li>
+                    <li><%= pet.adoptable %></li>
+                </ul>
+                </li>
+                <%= form_with url: "/applications/#{@application.id}", method: :get, local: true do |f| %>
+                    <%= f.hidden_field :added_pet, value: pet.id %>
+                    <%= f.submit "Adopt #{pet.name}" %>
+                <% end %>
+            <%end %> 
+        </ol>
+    <% end %>
+<% end %>
+
+
+
+
+
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,6 +39,8 @@ Rails.application.routes.draw do
   get "/veterinary_offices/:veterinary_office_id/veterinarians/new", to: "veterinarians#new"
   post "/veterinary_offices/:veterinary_office_id/veterinarians", to: "veterinarians#create"
 
+  get "/admin/applications/:id", to: "admin/applications#show" 
+
   get "/applications/new", to: "applications#new"
   get "/applications/:id", to: "applications#show"
   post "/applications", to: "applications#create"

--- a/db/migrate/20231214040246_add_status_to_application_pets.rb
+++ b/db/migrate/20231214040246_add_status_to_application_pets.rb
@@ -1,0 +1,9 @@
+class AddStatusToApplicationPets < ActiveRecord::Migration[7.0]
+  def change
+    add_column :application_pets, :status, :string
+  end
+end
+
+# row 1: id 1, application_id 1, pet_id 1, status 
+# row 2: id 2, application_id 2, pet_id 1, status
+# row 3: id 3, application_id 2, pet_id 2, status 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_12_11_174850) do
+ActiveRecord::Schema[7.0].define(version: 2023_12_14_040246) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -19,6 +19,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_11_174850) do
     t.bigint "application_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "status"
     t.index ["application_id"], name: "index_application_pets_on_application_id"
     t.index ["pet_id"], name: "index_application_pets_on_pet_id"
   end

--- a/spec/features/applications/admin/show_spec.rb
+++ b/spec/features/applications/admin/show_spec.rb
@@ -1,0 +1,189 @@
+require "rails_helper"
+
+RSpec.describe "the admin application show page" do
+  it "shows the application and all its attributes" do
+    shelter = Shelter.create(name: "Mystery Building", city: "Irvine CA", foster_program: false, rank: 9)
+    applicant = Application.create(name: "Shaggy", street_address: "123 Mystery Lane", city: "Irvine", state: "CA", zip_code: "91010", description: "Because Scoob and I love Scooby Snacks")
+    pet = applicant.pets.create(name: "Scooby", age: 2, breed: "Great Dane", adoptable: true, shelter_id: shelter.id)
+
+    visit "/admin/applications/#{applicant.id}"
+
+    expect(page).to have_content(applicant.name)
+    expect(page).to have_content(applicant.street_address)
+    expect(page).to have_content(applicant.city)
+    expect(page).to have_content(applicant.state)
+    expect(page).to have_content(applicant.zip_code)
+    expect(page).to have_content(applicant.description)
+    expect(page).to have_content(applicant.status)
+  end
+
+  it "shows pets associated with applicant" do
+    shelter = Shelter.create(name: "Mystery Building", city: "Irvine CA", foster_program: false, rank: 9)
+    applicant = Application.create(name: "Shaggy", street_address: "123 Mystery Lane", city: "Irvine", state: "CA", zip_code: "91010", description: "Because Scoob and I love Scooby Snacks")
+    pet = applicant.pets.create(name: "Scooby", age: 2, breed: "Great Dane", adoptable: true, shelter_id: shelter.id)
+
+    visit "/admin/applications/#{applicant.id}"
+
+    expect(page).to have_content(pet.name)
+  end
+
+  it "links to pets show page" do
+    shelter = Shelter.create(name: "Mystery Building", city: "Irvine CA", foster_program: false, rank: 9)
+    applicant = Application.create(name: "Shaggy", street_address: "123 Mystery Lane", city: "Irvine", state: "CA", zip_code: "91010", description: "Because Scoob and I love Scooby Snacks")
+    pet = applicant.pets.create(name: "Scooby", age: 2, breed: "Great Dane", adoptable: true, shelter_id: shelter.id)
+
+    visit "/admin/applications/#{applicant.id}"
+
+    click_link("Scooby")
+
+    expect(current_path).to eq("/pets/#{pet.id}")
+  end
+
+  it "shows a pets search field" do 
+    shelter = Shelter.create(name: "Mystery Building", city: "Irvine CA", foster_program: false, rank: 9)
+    applicant = Application.create(name: "Shaggy", street_address: "123 Mystery Lane", city: "Irvine", state: "CA", zip_code: "91010", description: "Because Scoob and I love Scooby Snacks")
+    pet = applicant.pets.create(name: "Scooby", age: 2, breed: "Great Dane", adoptable: true, shelter_id: shelter.id)
+
+    visit "/admin/applications/#{applicant.id}"
+    
+    expect(page).to have_content("Search for a pet to add")
+    
+  end
+
+  
+  it "shows pets matching user search input" do 
+    shelter = Shelter.create(name: "Mystery Building", city: "Irvine CA", foster_program: false, rank: 9)
+    applicant = Application.create(name: "Shaggy", street_address: "123 Mystery Lane", city: "Irvine", state: "CA", zip_code: "91010", description: "Because ")
+    pet = Pet.create(name: "Scooby", age: 2, breed: "Great Dane", adoptable: true, shelter_id: shelter.id)
+
+    visit "/admin/applications/#{applicant.id}"
+    
+    fill_in "Search", with: "scoob"
+
+    click_button "Search"
+    
+    expect(page).to have_content("Scooby")
+    
+  end
+
+  it 'shows a link to adopt a pet under each shown pet' do 
+    shelter = Shelter.create(name: "Mystery Building", city: "Irvine CA", foster_program: false, rank: 9)
+    applicant = Application.create(name: "Shaggy", street_address: "123 Mystery Lane", city: "Irvine", state: "CA", zip_code: "91010", description: "Because ")
+    pet = Pet.create(name: "Scooby", age: 2, breed: "Great Dane", adoptable: true, shelter_id: shelter.id)
+
+    visit "/admin/applications/#{applicant.id}"
+    fill_in "Search", with: "scoob"
+    
+    click_button "Search"
+    
+    
+    expect(page).to have_button("Adopt Scooby")
+    
+  end
+
+  it "shows added pets to the application" do 
+    shelter = Shelter.create(name: "Mystery Building", city: "Irvine CA", foster_program: false, rank: 9)
+    applicant = Application.create(name: "Shaggy", street_address: "123 Mystery Lane", city: "Irvine", state: "CA", zip_code: "91010", description: "Because ")
+    pet = Pet.create(name: "Scooby", age: 2, breed: "Great Dane", adoptable: true, shelter_id: shelter.id)
+
+    visit "/admin/applications/#{applicant.id}"
+    fill_in "Search", with: "scoob"
+    
+    click_button "Search"
+    click_button "Adopt #{pet.name}"
+    
+    visit "/admin/applications/#{applicant.id}"
+    
+    fill_in "Search", with: "z"
+    click_button "Search"
+    expect(page).to have_content("Scooby")
+    
+  end
+
+  it "does NOT show a section to explain why I'd make a good owner if I have NOT chosen pets to adopt (US-7)" do
+    shelter = Shelter.create(name: "Mystery Building", city: "Irvine CA", foster_program: false, rank: 9)
+    applicant = Application.create(name: "Shaggy", street_address: "123 Mystery Lane", city: "Irvine", state: "CA", zip_code: "91010", description: "Because ")
+    pet = Pet.create(name: "Scooby", age: 2, breed: "Great Dane", adoptable: true, shelter_id: shelter.id)
+
+    visit "/admin/applications/#{applicant.id}"
+
+    expect(page).to_not have_content("Why would you be a good owner")
+    expect(page).to_not have_field("Why would you be a good owner")
+  end
+
+  it " Successfully searches pets with partial inputs " do 
+    shelter = Shelter.create(name: "Mystery Building", city: "Irvine CA", foster_program: false, rank: 9)
+    applicant = Application.create(name: "Shaggy", street_address: "123 Mystery Lane", city: "Irvine", state: "CA", zip_code: "91010", description: "Because ")
+    pet = Pet.create(name: "Scooby", age: 2, breed: "Great Dane", adoptable: true, shelter_id: shelter.id)
+
+    visit "/admin/applications/#{applicant.id}"
+    
+    fill_in "Search", with: "oob"
+
+    click_button "Search"
+    
+    expect(page).to have_content("Scooby")
+    
+  end
+
+  it " Successfully searches pets with case insensitive inputs" do 
+    shelter = Shelter.create(name: "Mystery Building", city: "Irvine CA", foster_program: false, rank: 9)
+    applicant = Application.create(name: "Shaggy", street_address: "123 Mystery Lane", city: "Irvine", state: "CA", zip_code: "91010", description: "Because ")
+    pet = Pet.create(name: "Scooby", age: 2, breed: "Great Dane", adoptable: true, shelter_id: shelter.id)
+
+    visit "/admin/applications/#{applicant.id}"
+    
+    fill_in "Search", with: "SCoOb"
+
+    click_button "Search"
+    
+    expect(page).to have_content("Scooby")
+  end
+
+  it "shows a button to approve applicant's pets if pet is not already approved" do
+    shelter = Shelter.create(name: "Mystery Building", city: "Irvine CA", foster_program: false, rank: 9)
+    applicant = Application.create(name: "Shaggy", street_address: "123 Mystery Lane", city: "Irvine", state: "CA", zip_code: "91010", description: "Because ", status: "Pending")
+    pet = applicant.pets.create(name: "Scooby", age: 2, breed: "Great Dane", adoptable: true, shelter_id: shelter.id)
+    pet_2 = applicant.pets.create(name: "Doinkus", age: 1, breed: "Cool", adoptable: true, shelter_id: shelter.id)
+    application_pet = ApplicationPet.where({pet_id: pet.id},{application_id: applicant.id}).first.change_application_pet_status("Approved")
+
+    visit "/admin/applications/#{applicant.id}"
+
+    # save_and_open_page
+
+    expect(page).to_not have_button("Approve #{pet.name}")
+    expect(page).to have_button("Approve #{pet_2.name}")
+    expect(page).to have_content("#{pet.name} already approved)")
+  end
+
+  it "has a button that approves a pet for an applicant" do
+    shelter = Shelter.create(name: "Mystery Building", city: "Irvine CA", foster_program: false, rank: 9)
+    applicant = Application.create(name: "Shaggy", street_address: "123 Mystery Lane", city: "Irvine", state: "CA", zip_code: "91010", description: "Because ", status: "Pending")
+    pet = applicant.pets.create(name: "Scooby", age: 2, breed: "Great Dane", adoptable: true, shelter_id: shelter.id)
+    pet_2 = applicant.pets.create(name: "Doinkus", age: 1, breed: "Cool", adoptable: true, shelter_id: shelter.id)
+
+    visit "/admin/applications/#{applicant.id}"
+
+    expect(page).to have_button("Approve #{pet.name}")
+    expect(page).to have_button("Approve #{pet_2.name}")
+
+    click_button "Approve #{pet.name}"
+
+    expect(page).to_not have_button("Approve #{pet.name}")
+    expect(page).to have_button("Approve #{pet_2.name}")
+
+    save_and_open_page
+  end
+
+  # it "allows the user to delete a pet" do
+  #   shelter = Shelter.create(name: "Mystery Building", city: "Irvine CA", foster_program: false, rank: 9)
+  #   pet = Pet.create(name: "Scrappy", age: 1, breed: "Great Dane", adoptable: true, shelter_id: shelter.id)
+
+  #   visit "/pets/#{pet.id}"
+
+  #   click_on("Delete #{pet.name}")
+
+  #   expect(page).to have_current_path("/pets")
+  #   expect(page).to_not have_content(pet.name)
+  # end
+end

--- a/spec/features/shelters/admin/index_spec.rb
+++ b/spec/features/shelters/admin/index_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "the shelters index" do
+RSpec.describe "the admin shelters index" do
   before(:each) do
     @shelter_1 = Shelter.create(name: "Aurora shelter", city: "Aurora, CO", foster_program: false, rank: 9)
     @shelter_2 = Shelter.create(name: "RGV animal shelter", city: "Harlingen, TX", foster_program: false, rank: 5)

--- a/spec/models/application_pet_spec.rb
+++ b/spec/models/application_pet_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.describe ApplicationPet, type: :model do
+    describe "relationships" do
+      it { should belong_to(:pet) }
+      it { should belong_to(:application) }
+    end
+
+    before(:each) do
+      @shelter_1 = Shelter.create(name: "Mystery Building", city: "Irvine CA", foster_program: false, rank: 9)
+      @shelter_2 = Shelter.create(name: "New Shelter", city: "Irvine CA", foster_program: false, rank: 9)
+      @applicant_who_has_pets = Application.create(name: "Shaggy", street_address: "123 Mystery Lane", city: "Irvine", state: "CA", zip_code: "91010", description: "Because",status:"Pending")
+      @pet = @applicant_who_has_pets.pets.create(name: "Scooby", age: 2, breed: "Great Dane", adoptable: true, shelter_id: @shelter_1.id)
+
+    end
+
+    describe "#change_application_pet_status" do 
+      it "changes an application pet's status" do 
+        application_pet = ApplicationPet.where({pet_id: @pet.id},{application_id: @applicant_who_has_pets.id}).first
+
+        expect(application_pet.status).to eq(nil)
+
+        application_pet.change_application_pet_status("fart")
+
+        expect(application_pet.status).to eq("fart")
+      end
+    end   
+end


### PR DESCRIPTION
Co-authored by Martin and Dylan.

```
As a visitor
When I visit an admin application show page ('/admin/applications/:id')
For every pet that the application is for, I see a button to approve the application for that specific pet
When I click that button
Then I'm taken back to the admin application show page
And next to the pet that I approved, I do not see a button to approve this pet
And instead I see an indicator next to the pet that they have been approved
```