### PR TITLE
US-13: Rejecting a Pet for Adoption

### DIFF
--- a/app/controllers/admin/applications_controller.rb
+++ b/app/controllers/admin/applications_controller.rb
@@ -18,5 +18,11 @@ class Admin::ApplicationsController < ApplicationController
             application_pet = ApplicationPet.where({pet_id: pet_id},{application_id: @application.id}).first
             application_pet.change_application_pet_status("Approved")
         end
+
+        if params[:rejected_pet_id].present?
+            pet_id = params[:rejected_pet_id]
+            application_pet = ApplicationPet.where({pet_id: pet_id},{application_id: @application.id}).first
+            application_pet.change_application_pet_status("Rejected")
+        end
     end
 end

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -9,10 +9,6 @@ class Application < ApplicationRecord
   validates :zip_code, presence: true, numericality: true, length: { is: 5 }
   validates :description, presence: true
 
-  def self.order_by_recently_created
-    order(created_at: :desc)
-  end
-
   def add_pet_to_application(pet_id)
     pet = Pet.find(pet_id)
     self.pets << pet

--- a/app/views/admin/applications/show.html.erb
+++ b/app/views/admin/applications/show.html.erb
@@ -11,13 +11,19 @@
 <ul>
     <% @application.pets.each do |pet| %>
         <li><p><%= link_to "#{pet.name}", "/pets/#{pet.id}" %></p></li>
-        <% if ApplicationPet.where({pet_id: pet.id},{application_id: @application.id}).first.status != "Approved" %>
+        <% if ApplicationPet.where({pet_id: pet.id},{application_id: @application.id}).first.status == "Approved" %>
+            <%= "(#{pet.name} already approved)" %>
+        <% elsif ApplicationPet.where({pet_id: pet.id},{application_id: @application.id}).first.status == "Rejected" %>
+            <%= "(#{pet.name} already rejected)" %>
+        <% else %>
             <%= form_with url: "/admin/applications/#{@application.id}", method: :get, local: true do |f| %>
                 <%= f.hidden_field :approved_pet_id, value: pet.id %>
                 <%= f.submit "Approve #{pet.name}" %>
             <% end %>
-        <% else %>
-            <%= "(#{pet.name} already approved)" %>
+            <%= form_with url: "/admin/applications/#{@application.id}", method: :get, local: true do |f| %>
+                <%= f.hidden_field :rejected_pet_id, value: pet.id %>
+                <%= f.submit "Reject #{pet.name}" %>
+            <% end %>
         <% end %>   
     <% end %>
 </ul>

--- a/spec/features/applications/admin/show_spec.rb
+++ b/spec/features/applications/admin/show_spec.rb
@@ -140,20 +140,24 @@ RSpec.describe "the admin application show page" do
     expect(page).to have_content("Scooby")
   end
 
-  it "shows a button to approve applicant's pets if pet is not already approved" do
+  it "shows a button to approve applicant's pets if pet is not already approved or rejected" do
     shelter = Shelter.create(name: "Mystery Building", city: "Irvine CA", foster_program: false, rank: 9)
     applicant = Application.create(name: "Shaggy", street_address: "123 Mystery Lane", city: "Irvine", state: "CA", zip_code: "91010", description: "Because ", status: "Pending")
     pet = applicant.pets.create(name: "Scooby", age: 2, breed: "Great Dane", adoptable: true, shelter_id: shelter.id)
     pet_2 = applicant.pets.create(name: "Doinkus", age: 1, breed: "Cool", adoptable: true, shelter_id: shelter.id)
+    pet_3 = applicant.pets.create(name: "Booger", age: 400, breed: "Tree", adoptable: true, shelter_id: shelter.id)
     application_pet = ApplicationPet.where({pet_id: pet.id},{application_id: applicant.id}).first.change_application_pet_status("Approved")
+    application_pet_3 = ApplicationPet.where({pet_id: pet_3.id},{application_id: applicant.id}).first.change_application_pet_status("Rejected")
 
     visit "/admin/applications/#{applicant.id}"
 
-    # save_and_open_page
+    save_and_open_page
 
     expect(page).to_not have_button("Approve #{pet.name}")
     expect(page).to have_button("Approve #{pet_2.name}")
+    expect(page).to_not have_button("Approve #{pet_3.name}")
     expect(page).to have_content("#{pet.name} already approved)")
+    expect(page).to have_content("#{pet_3.name} already rejected)")
   end
 
   it "has a button that approves a pet for an applicant" do
@@ -171,8 +175,23 @@ RSpec.describe "the admin application show page" do
 
     expect(page).to_not have_button("Approve #{pet.name}")
     expect(page).to have_button("Approve #{pet_2.name}")
+  end
 
-    save_and_open_page
+  it "has a button that rejects a pet for an applicant" do
+    shelter = Shelter.create(name: "Mystery Building", city: "Irvine CA", foster_program: false, rank: 9)
+    applicant = Application.create(name: "Shaggy", street_address: "123 Mystery Lane", city: "Irvine", state: "CA", zip_code: "91010", description: "Because ", status: "Pending")
+    pet = applicant.pets.create(name: "Scooby", age: 2, breed: "Great Dane", adoptable: true, shelter_id: shelter.id)
+    pet_2 = applicant.pets.create(name: "Doinkus", age: 1, breed: "Cool", adoptable: true, shelter_id: shelter.id)
+
+    visit "/admin/applications/#{applicant.id}"
+
+    expect(page).to have_button("Reject #{pet.name}")
+    expect(page).to have_button("Reject #{pet_2.name}")
+
+    click_button "Reject #{pet.name}"
+
+    expect(page).to_not have_button("Reject #{pet.name}")
+    expect(page).to have_button("Reject #{pet_2.name}")
   end
 
   # it "allows the user to delete a pet" do

--- a/spec/models/pet_spec.rb
+++ b/spec/models/pet_spec.rb
@@ -38,5 +38,17 @@ RSpec.describe Pet, type: :model do
         expect(@pet_3.shelter_name).to eq(@shelter_1.name)
       end
     end
+
+    describe ".add_pet_to_application" do
+      it "adds a pet to an application" do
+        application = Application.create(name: "Shaggy", street_address: "123 Mystery Lane", city: "Irvine", state: "CA", zip_code: "91010", description: "Because")
+
+        expect(application.pets).to_not include(@pet_1)
+
+        application.add_pet_to_application(@pet_1.id)
+
+        expect(application.pets).to include(@pet_1)
+      end
+    end
   end
 end


### PR DESCRIPTION
Co-authored by Martin and Dylan!
```
As a visitor
When I visit an admin application show page ('/admin/applications/:id')
For every pet that the application is for, I see a button to reject the application for that specific pet
When I click that button
Then I'm taken back to the admin application show page
And next to the pet that I rejected, I do not see a button to approve or reject this pet
And instead I see an indicator next to the pet that they have been rejected
```