### PR TITLE
US-14: Approved/Rejected Pets on one Application do not affect other …

### DIFF
--- a/app/controllers/admin/applications_controller.rb
+++ b/app/controllers/admin/applications_controller.rb
@@ -15,13 +15,13 @@ class Admin::ApplicationsController < ApplicationController
 
         if params[:approved_pet_id].present?
             pet_id = params[:approved_pet_id]
-            application_pet = ApplicationPet.where({pet_id: pet_id},{application_id: @application.id}).first
+            application_pet = ApplicationPet.where({pet_id: pet_id,application_id: @application.id}).first
             application_pet.change_application_pet_status("Approved")
         end
 
         if params[:rejected_pet_id].present?
             pet_id = params[:rejected_pet_id]
-            application_pet = ApplicationPet.where({pet_id: pet_id},{application_id: @application.id}).first
+            application_pet = ApplicationPet.where({pet_id: pet_id,application_id: @application.id}).first
             application_pet.change_application_pet_status("Rejected")
         end
     end

--- a/app/views/admin/applications/show.html.erb
+++ b/app/views/admin/applications/show.html.erb
@@ -11,9 +11,9 @@
 <ul>
     <% @application.pets.each do |pet| %>
         <li><p><%= link_to "#{pet.name}", "/pets/#{pet.id}" %></p></li>
-        <% if ApplicationPet.where({pet_id: pet.id},{application_id: @application.id}).first.status == "Approved" %>
+        <% if ApplicationPet.where({pet_id: pet.id,application_id: @application.id}).first.status == "Approved" %>
             <%= "(#{pet.name} already approved)" %>
-        <% elsif ApplicationPet.where({pet_id: pet.id},{application_id: @application.id}).first.status == "Rejected" %>
+        <% elsif ApplicationPet.where({pet_id: pet.id,application_id: @application.id}).first.status == "Rejected" %>
             <%= "(#{pet.name} already rejected)" %>
         <% else %>
             <%= form_with url: "/admin/applications/#{@application.id}", method: :get, local: true do |f| %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,8 +8,8 @@
 
 shelter_1 = Shelter.create(name: "Mystery Building", city: "Irvine CA", foster_program: false, rank: 9)
 shelter_2 = Shelter.create(name: "New Shelter", city: "Irvine CA", foster_program: false, rank: 9)
-applicant_who_has_pets = Application.create(name: "Shaggy", street_address: "123 Mystery Lane", city: "Irvine", state: "CA", zip_code: "91010", description: "Because",status:"Pending")
-applicant_who_has_no_pets = Application.create(name: "Daphne", street_address: "4 North Street", city: "Boulder", state: "CO", zip_code: "80209", description: "I want a pet")
-pet = applicant_who_has_pets.pets.create(name: "Scooby", age: 2, breed: "Great Dane", adoptable: true, shelter_id: shelter_1.id)
-cat = Pet.create(name: "Catdog", age: 4, breed: "Calico", adoptable: true, shelter_id: shelter_1.id)
+shaggy = Application.create(name: "Shaggy", street_address: "123 Mystery Lane", city: "Irvine", state: "CA", zip_code: "91010", description: "Because")
+daphne = Application.create(name: "Daphne", street_address: "4 North Street", city: "Boulder", state: "CO", zip_code: "80209", description: "I want a pet")
+scooby = shaggy.pets.create(name: "Scooby", age: 2, breed: "Great Dane", adoptable: true, shelter_id: shelter_1.id)
+catdog = Pet.create(name: "Catdog", age: 4, breed: "Calico", adoptable: true, shelter_id: shelter_1.id)
 

--- a/spec/features/applications/admin/show_spec.rb
+++ b/spec/features/applications/admin/show_spec.rb
@@ -151,8 +151,6 @@ RSpec.describe "the admin application show page" do
 
     visit "/admin/applications/#{applicant.id}"
 
-    save_and_open_page
-
     expect(page).to_not have_button("Approve #{pet.name}")
     expect(page).to have_button("Approve #{pet_2.name}")
     expect(page).to_not have_button("Approve #{pet_3.name}")

--- a/spec/models/application_pet_spec.rb
+++ b/spec/models/application_pet_spec.rb
@@ -9,20 +9,34 @@ RSpec.describe ApplicationPet, type: :model do
     before(:each) do
       @shelter_1 = Shelter.create(name: "Mystery Building", city: "Irvine CA", foster_program: false, rank: 9)
       @shelter_2 = Shelter.create(name: "New Shelter", city: "Irvine CA", foster_program: false, rank: 9)
-      @applicant_who_has_pets = Application.create(name: "Shaggy", street_address: "123 Mystery Lane", city: "Irvine", state: "CA", zip_code: "91010", description: "Because",status:"Pending")
-      @pet = @applicant_who_has_pets.pets.create(name: "Scooby", age: 2, breed: "Great Dane", adoptable: true, shelter_id: @shelter_1.id)
-
+      @shaggy = Application.create(name: "Shaggy", street_address: "123 Mystery Lane", city: "Irvine", state: "CA", zip_code: "91010", description: "Because", status:"Pending")
+      @daphne = Application.create(name: "Daphne", street_address: "4 North Street", city: "Boulder", state: "CO", zip_code: "80209", description: "I want a pet", status:"Pending")
+      @scooby = Pet.create(name: "Scooby", age: 2, breed: "Great Dane", adoptable: true, shelter_id: @shelter_1.id)
+      @shaggy.add_pet_to_application(@scooby.id)
+      @daphne.add_pet_to_application(@scooby.id)
     end
 
     describe "#change_application_pet_status" do 
       it "changes an application pet's status" do 
-        application_pet = ApplicationPet.where({pet_id: @pet.id},{application_id: @applicant_who_has_pets.id}).first
+        application_pet = ApplicationPet.where({pet_id: @scooby.id, application_id: @shaggy.id}).first
 
         expect(application_pet.status).to eq(nil)
 
         application_pet.change_application_pet_status("fart")
 
         expect(application_pet.status).to eq("fart")
+      end
+
+      it "does not change a different application pet's status when there are two or more applications for the same pet" do
+        application_pet_1 = ApplicationPet.where({pet_id: @scooby.id, application_id: @shaggy.id}).first
+        application_pet_2 = ApplicationPet.where({pet_id: @scooby.id, application_id: @daphne.id}).first
+
+        expect(application_pet_1.status).to eq(nil)
+        expect(application_pet_2.status).to eq(nil)
+
+        application_pet_1.change_application_pet_status("fart")
+        expect(application_pet_1.status).to eq("fart")
+        expect(application_pet_2.status).to_not eq("fart")
       end
     end   
 end


### PR DESCRIPTION
Co-authored by Martin and Dylan!
```
14. Approved/Rejected Pets on one Application do not affect other Applications

As a visitor
When there are two applications in the system for the same pet
When I visit the admin application show page for one of the applications
And I approve or reject the pet for that application
When I visit the other application's admin show page
Then I do not see that the pet has been accepted or rejected for that application
And instead I see buttons to approve or reject the pet for this specific application
```